### PR TITLE
Fix error when installing extension

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -59,7 +59,6 @@ module.exports = (grunt) ->
 			"128": "icon128.png"
 			
 		mnf.background?.scripts ?= []
-		mnf.background.scripts.push 'reload.js'
 		
 		grunt.file.write 'ext/manifest.json', JSON.stringify(mnf)
 		


### PR DESCRIPTION
After running `grunt build` I was getting an error when trying to load the extension's directory in Chrome:

<img width="733" alt="screen shot 2016-02-13 at 12 40 05" src="https://cloud.githubusercontent.com/assets/3476612/13029939/f363c4d6-d24e-11e5-982c-3c75ec0c2709.png">

Text of error is below:

```
{"name":"Gmail GitHub Extension","description":"","version":"0.1","content_scripts":[{"matches":["https://mail.google.com/*","https://inbox.google.com/*"],"js":["inboxsdk.js","content.js"],"run_at":"document_end"}],"background":{"scripts":["background.js","reload.js"]},"permissions":["https://mail.google.com/","https://inbox.google.com/","https://github.com/"],"web_accessible_resources":["images/*.png"],"manifest_version":2,"icons":{"16":"icon16.png","48":"icon48.png","128":"icon128.png"}}
Retry
```

It seems the error is being caused by `reload.js` being added to `manifest.json` during the build step so I removed it.
